### PR TITLE
Update log4j to 2.17.0 to address CVE-2021-45105.

### DIFF
--- a/discount/pom.xml
+++ b/discount/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <version>2.17.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105